### PR TITLE
Add support for Termux-specific project creation using --termux flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,21 @@ dev create <framework> --name <project-name>
 **Example:**
 
 ```bash
-dev create next --name next-app
+dev create express --name express-app
 ```
 
 ```bash
-dev create react -n react-app
+dev create nest -n nest-app
+```
+
+**Project for Termux:**
+
+```bash
+dev create next --name next-app --termux
+```
+
+```bash
+dev create react -n react-app -T
 ```
 
 **List Available Frameworks**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devcorex/dev.x",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devcorex/dev.x",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcorex/dev.x",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "index.js",
   "type": "module",
   "bin": {

--- a/src/commands/create/express.js
+++ b/src/commands/create/express.js
@@ -1,0 +1,243 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import inquirer from "inquirer";
+
+export const createExpressApp = async (name) => {
+  try {
+    // config inquirer answers
+    const answers = await inquirer.prompt([
+      {
+        type: "list",
+        name: "language",
+        message: "In what language do you want to create the project?",
+        choices: ["TypeScript", "JavaScript"],
+      },
+    ]);
+
+    if (answers.language === "JavaScript") {
+      // create express app
+      fs.mkdirSync(name, { recursive: true });
+
+      // change directory
+      process.chdir(name);
+
+      // create package.json
+      const packageJsonContent = `{
+  "name": "${name}",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch --env-file=.env src/index.js",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}`;
+      fs.writeFileSync("./package.json", packageJsonContent, {
+        encoding: "utf8",
+      });
+
+      // install aditional modules
+      execSync(
+        `npm install express morgan cors axios bcryptjs jsonwebtoken mongoose`,
+        { stdio: "inherit" },
+      );
+
+      // create .env file
+      const envFile = `PORT=4000`;
+      fs.writeFileSync("./.env", envFile, { encoding: "utf8" });
+
+      // create src and config directory
+      fs.mkdirSync("src/config", { recursive: true });
+
+      // create app script
+      const appContent = `import express from "express";
+import morgan from "morgan";
+import cors from "cors";
+
+const app = express();
+
+app.use(morgan('dev'));
+app.use(cors());
+app.use(express.json());
+
+export default app;`;
+      fs.writeFileSync("./src/app.js", appContent, { encoding: "utf8" });
+
+      // create config script
+      const configContent = `export const PORT = process.env.PORT || 4000;`;
+      fs.writeFileSync("./src/config/config.js", configContent, {
+        encoding: "utf8",
+      });
+
+      // create main script
+      const indexContent = `import app from "./app.js";
+import { PORT } from "./config/config.js";
+
+function main() {
+  try {
+    app.listen(PORT, () => {
+      console.log('http://localhost:' + PORT);
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+main();`;
+
+      fs.writeFileSync("./src/index.js", indexContent, { encoding: "utf8" });
+    } else {
+      // create express/typescript app
+      fs.mkdirSync(name, { recursive: true });
+
+      // change directory
+      process.chdir(name);
+
+      // create package.json
+      const packageJsonContent = `{
+  "name": "${name}",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "ts-node-dev --env-file=.env --respawn src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}`;
+      fs.writeFileSync("./package.json", packageJsonContent, {
+        encoding: "utf8",
+      });
+
+      // install aditional modules
+      execSync(
+        `npm install express morgan cors axios bcryptjs jsonwebtoken typeorm reflect-metadata pg`,
+        { stdio: "inherit" },
+      );
+
+      // install devDependencies
+      execSync(
+        `npm install typescript ts-node-dev @types/node @types/express @types/morgan @types/cors @types/bcryptjs @types/jsonwebtoken -D`,
+        { stdio: "inherit" },
+      );
+
+      // create directory
+      fs.mkdirSync("src/config", { recursive: true });
+      fs.mkdirSync("src/entities", { recursive: true });
+
+      // create tsconfig file
+      const tsconfigContent = `{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}`;
+
+      fs.writeFileSync("./tsconfig.json", tsconfigContent, {
+        encoding: "utf8",
+      });
+
+      // create orm config file
+      const ormConfigContent = `import { DataSource } from "typeorm";
+
+const AppDataSource = new DataSource({
+  type: "postgres",
+  host: "localhost",
+  port: 5432,
+  username: "your_username",
+  password: "your_password",
+  database: "your_database",
+  synchronize: true, // dev only
+  logging: false,
+  entities: ["src/entities/*.ts"],
+  migrations: ["src/migrations/*.ts"],
+  subscribers: ["src/subscribers/*.ts"],
+});
+
+export default AppDataSource;`;
+
+      fs.writeFileSync("./src/ormconfig.ts", ormConfigContent, {
+        encoding: "utf8",
+      });
+
+      // create .env file
+      const envFile = `PORT=4000`;
+      fs.writeFileSync("./.env", envFile, { encoding: "utf8" });
+
+      // create config script
+      const configContent = `export const PORT = process.env.PORT || 4000;`;
+      fs.writeFileSync("./src/config/config.ts", configContent, {
+        encoding: "utf8",
+      });
+
+      // create User entitie
+      const userEntitieContent = `import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  password: string;
+}`;
+      fs.writeFileSync("./src/entities/User.ts", userEntitieContent, {
+        encoding: "utf8",
+      });
+
+      // create app script
+      const appContent = `import express from "express";
+import morgan from "morgan";
+import cors from "cors";
+
+const app = express();
+
+app.use(morgan('dev'));
+app.use(cors());
+app.use(express.json());
+
+export default app;`;
+      fs.writeFileSync("./src/app.ts", appContent, { encoding: "utf8" });
+
+      // create main script
+      const indexContent = `import app from "./app";
+import { PORT } from "./config/config";
+
+function main() {
+  try {
+    app.listen(PORT, () => {
+      console.log('http://localhost:' + PORT);
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+main();`;
+
+      fs.writeFileSync("./src/index.ts", indexContent, { encoding: "utf8" });
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/commands/create/index.js
+++ b/src/commands/create/index.js
@@ -2,9 +2,12 @@
 //import path from "path";
 import chalk from "chalk";
 import Table from "cli-table3";
-import { execSync } from "child_process";
 import __dirname from "../../utils/pathUtils.js";
 import { frameworkList } from "../../data/frameworkList.js";
+import { createNextApp } from "./next.js";
+import { createExpressApp } from "./express.js";
+import { createNestApp } from "./nest.js";
+import { createReactApp } from "./react.js";
 
 export const command = "create [framework]";
 export const describe = "Create a new project";
@@ -27,17 +30,25 @@ export const builder = {
     alias: "l",
     default: false,
   },
+  termux: {
+    describe: "Create project for Termux enviroment",
+    type: "boolean",
+    alias: "T",
+    default: false,
+  }
 };
 
-export const handler = (argv) => {
-  const { framework, name, list } = argv;
+export const handler = async (argv) => {
+  const { framework, name, list, termux } = argv;
 
+  // create table
   if (list) {
     const table = new Table({
       head: [chalk.red.bold("Framework"), chalk.red.bold("Description")],
       colWidths: [20, 30],
     });
 
+    // show table
     frameworkList.forEach((item) => {
       table.push([chalk.cyan(item.name), chalk.gray(item.description)]);
     });
@@ -47,12 +58,14 @@ export const handler = (argv) => {
     process.exit(0);
   }
 
+  // error: need framework
   if (!framework) {
     console.log(chalk.red("Error: You must specify a framework to create a project."));
     console.log(chalk.yellow("Use the '--list' or '-l' flag to see available frameworks."));
     process.exit(1);
   }
 
+  // framework is not supported
   const isValidFramework = frameworkList.some((item) => item.name === framework);
 
   if (!isValidFramework) {
@@ -61,20 +74,21 @@ export const handler = (argv) => {
     process.exit(1);
   }
 
+  // create framework app
   try {
     console.log(chalk.blue(`Initializing ${framework} project '${name}'...`));
     switch (framework) {
       case "next":
-        execSync(`npx create-next-app@latest ${name}`, { stdio: "inherit" });
+        await createNextApp(name, termux);
         break;
       case "react":
-        execSync(`npx create-vite@latest ${name}`, { stdio: "inherit" });
+        await createReactApp(name, termux);
         break;
       case "nest":
-        execSync(`npx @nestjs/cli new ${name}`, { stdio: "inherit" });
+        await createNestApp(name);
         break;
       case "express":
-        execSync(`npx express-generator ${name}`, { stdio: "inherit" });
+        await createExpressApp(name);
         break;
       default:
         throw new Error(`Unsupported framework: ${framework}`);

--- a/src/commands/create/nest.js
+++ b/src/commands/create/nest.js
@@ -1,0 +1,5 @@
+import { execSync } from "child_process";
+
+export const createNestApp = async (name) => {
+  execSync(`npx @nestjs/cli new ${name}`, { stdio: "inherit" });
+}

--- a/src/commands/create/next.js
+++ b/src/commands/create/next.js
@@ -1,0 +1,79 @@
+import { execSync } from "child_process";
+import fs from "fs";
+
+export const createNextApp = async (name, termux) => {
+  try {
+    // create next app
+    execSync(`npx create-next-app@latest ${name}`, { stdio: "inherit" });
+
+    // change directory
+    process.chdir(name);
+
+    // check termux environment
+    if (termux) {
+      // check if tailwindcss is installed
+      const isTailwindInstalled = (() => {
+        try {
+          execSync(`npm list tailwindcss`, { stdio: "ignore" });
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+
+      if (isTailwindInstalled) {
+        execSync(`npm uninstall tailwindcss`, { stdio: "inherit" });
+      }
+
+      // install a compatible version of tailwindcss
+      execSync(
+        `npm install tailwindcss@3.4.17 postcss autoprefixer`,
+        { stdio: "inherit" }
+      );
+
+      // initialize configuration file
+      execSync(`npx tailwindcss init -p`, { stdio: "inherit" });
+
+      // write tailwindcss config file
+      const configTailwind = `/** @type {import("tailwindcss").Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}`;
+      fs.writeFileSync('./tailwind.config.js', configTailwind, { encoding: "utf8" });
+
+      // check if src/app directory exists
+      const globalStylesPath = fs.existsSync('./src/app')
+        ? './src/app/globals.css'
+        : './src/globals.css';
+
+      // write global styles
+      const utilitiesTailwind = `@tailwind base;
+@tailwind components;
+@tailwind utilities;`;
+      fs.writeFileSync(globalStylesPath, utilitiesTailwind, { encoding: "utf8" });
+
+      // install prettier for tailwindcss
+      execSync(`npm install -D prettier prettier-plugin-tailwindcss`, { stdio: "inherit" });
+
+      // write prettier config
+      const prettierTailwind = `{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}`;
+      fs.writeFileSync('./.prettierrc', prettierTailwind, { encoding: "utf8" });
+    }
+
+    // delete the .git directory
+    if (fs.existsSync('./.git')) {
+      fs.rmSync('./.git', { recursive: true, force: true });
+    }
+  } catch (error) {
+    console.error("An error occurred:", error.message);
+  }
+};

--- a/src/commands/create/react.js
+++ b/src/commands/create/react.js
@@ -1,0 +1,99 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+export const createReactApp = async (name, termux) => {
+  try {
+    // create a new react project
+    execSync(`npx create-vite@latest ${name}`, { stdio: "inherit" });
+
+    // change directory
+    process.chdir(name);
+
+    // install dependencies
+    execSync(`npm install`, { stdio: "inherit" });
+
+    // install additional modules
+    execSync(`npm install react-router-dom`, { stdio: "inherit" });
+
+    // check Termux environment
+    if (termux) {
+      // install a compatible version of TailwindCSS
+      execSync(`npm install tailwindcss@3.4.17 postcss autoprefixer`, {
+        stdio: "inherit",
+      });
+
+      // initialize configuration file
+      execSync(`npx tailwindcss init -p`, { stdio: "inherit" });
+
+      // write TailwindCSS configuration
+      const configTailwind = `/** @type {import("tailwindcss").Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}`;
+      fs.writeFileSync("./tailwind.config.js", configTailwind, {
+        encoding: "utf8",
+      });
+
+      // configure global styles for TailwindCSS
+      const utilitiesTailwind = `@tailwind base;
+@tailwind components;
+@tailwind utilities;`;
+      fs.writeFileSync("./src/index.css", utilitiesTailwind, {
+        encoding: "utf8",
+      });
+
+      // install Prettier and TailwindCSS plugin
+      execSync(`npm install -D prettier prettier-plugin-tailwindcss`, {
+        stdio: "inherit",
+      });
+
+      // write prettier configuration
+      const prettierTailwind = `{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}`;
+      fs.writeFileSync("./.prettierrc", prettierTailwind, { encoding: "utf8" });
+    } else {
+      // install TailwindCSS for other environments
+      execSync(`npm install tailwindcss @tailwindcss/vite`, {
+        stdio: "inherit",
+      });
+
+      // check for vite.config.js or vite.config.ts
+      const viteConfigPathJS = path.join(process.cwd(), "vite.config.js");
+      const viteConfigPathTS = path.join(process.cwd(), "vite.config.ts");
+
+      const viteConfigContent = `import { defineConfig } from 'vite'
+import tailwindcss from '@tailwindcss/vite'
+export default defineConfig({
+  plugins: [
+    tailwindcss(),
+  ],
+})`;
+
+      if (fs.existsSync(viteConfigPathTS)) {
+        fs.writeFileSync(viteConfigPathTS, viteConfigContent, { encoding: "utf8" });
+      } else if (fs.existsSync(viteConfigPathJS)) {
+        fs.writeFileSync(viteConfigPathJS, viteConfigContent, { encoding: "utf8" });
+      } else {
+        // if neither exists, create a vite.config.js file
+        fs.writeFileSync("vite.config.js", viteConfigContent, { encoding: "utf8" });
+      }
+
+      // add TailwindCSS utilities
+      const utilitiesTailwind = `@import "tailwindcss";`;
+      fs.writeFileSync("./src/index.css", utilitiesTailwind, {
+        encoding: "utf8",
+      });
+    }
+  } catch (error) {
+    console.error("An error occurred:", error.message);
+  }
+};


### PR DESCRIPTION
This pull request introduces the following changes:

Adds a new optional flag --termux (or -T) to the dev create command.

When used, it configures the created project specifically for the Termux environment.

Example: dev create next --name next-app --termux


Updates the create command logic to handle Termux-specific setups seamlessly.

Maintains backward compatibility—if --termux is not provided, projects are created as usual.


Additionally, this pull request prepares the repository for version 1.1.0, reflecting the added functionality.