### PR TITLE
Add skip-install support for Next.js projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devcorex/dev.x",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devcorex/dev.x",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcorex/dev.x",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "index.js",
   "type": "module",
   "bin": {

--- a/src/commands/create/next.js
+++ b/src/commands/create/next.js
@@ -4,13 +4,19 @@ import fs from "fs";
 export const createNextApp = async (name, termux) => {
   try {
     // create next app
-    execSync(`npx create-next-app@latest ${name}`, { stdio: "inherit" });
+    execSync(`npx create-next-app@latest ${name} --skip-install`, { stdio: "inherit" });
 
     // change directory
     process.chdir(name);
 
     // check termux environment
     if (termux) {
+      // install only compatible dependencies
+      execSync(
+        `npm install --ignore-scripts`,
+        { stdio: "inherit" }
+      );
+
       // check if tailwindcss is installed
       const isTailwindInstalled = (() => {
         try {


### PR DESCRIPTION
This PR adjusts the Next.js project setup in Termux environments to avoid compatibility issues with dependencies running postinstall scripts. Dependencies are now manually installed using npm install --ignore-scripts, addressing specific errors with the @unrs/resolver library.